### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ dependencies {
     // Use the following line to include client library from Maven Central Repository
     // Change the version number from the search.maven.org result
     //
-    compile 'com.microsoft.projectoxford:emotion:1.0.0'
+    implementation 'com.microsoft.projectoxford:emotion:1.0.0'
 
     // Your other Dependencies...
 }


### PR DESCRIPTION
The compile configuration is now deprecated and should be replaced by implementation or api.
From [Gradle Documentation](https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_separation)